### PR TITLE
[codex] Add GitHub Trending tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## 1. Project Summary
 
-InsightFlow is a **serverless AI tech news tracker** that runs daily via GitHub Actions (08:00 KST). It scrapes articles from 3 sources, summarizes them with Gemini AI, tracks AI model performance/pricing, and delivers results to Telegram + Notion.
+InsightFlow is a **serverless AI tech news tracker** that runs daily via GitHub Actions (08:00 KST). It scrapes articles from 3 sources, summarizes them with Gemini AI, tracks GitHub Trending repositories and AI model performance/pricing, and delivers results to Telegram + Notion.
 
 - **Language**: Python 3.11+ (typed, `from __future__ import annotations`)
 - **Package Manager**: `uv` (lockfile: `uv.lock`)
@@ -22,6 +22,7 @@ src/
 ├── main.py                    # Orchestrator — 8-step sequential pipeline
 ├── config.py                  # Module-level constants + env vars (no classes)
 ├── scraper.py                 # Article dataclass + 3 fetchers (GeekNews/HN/TLDR)
+├── github_trending.py         # GitHub Trending repos + daily JSON snapshots
 ├── storage.py                 # JSON persistence + dedup (seen_ids.json) + GitHub Issues
 ├── ai_handler.py              # Gemini batch summarization + keyword filter
 ├── model_tracker.py           # Artificial Analysis API + SQLite snapshots + change detection
@@ -42,6 +43,7 @@ tests/
 ├── test_main.py               # Pipeline orchestration tests
 ├── test_scraper.py            # Scraper config + asyncio usage
 ├── test_scraper_behavior.py   # Scraper behavioral tests
+├── test_github_trending.py    # GitHub Trending parsing + storage
 ├── test_ai_handler.py         # Batch separation by source
 ├── test_storage.py            # Storage operations
 ├── test_notifier.py           # Telegram formatting + escape edge cases
@@ -65,6 +67,7 @@ tests/
 7. Model tracker pipeline          → fetch → SQLite snapshot → change detection
    7.5 send_model_updates_to_notion()  → [skipped in dry_run]
    7.6 sync_models_to_dashboard()      → [skipped in dry_run]
+   7.7 fetch_github_trending() + save_daily_trending_repos()
 8. send_digest()                   → Telegram [skipped in dry_run]
 ```
 
@@ -117,6 +120,7 @@ class Article:
 | **GeekNews** | `scraper.py` | Atom RSS feed via `feedparser` | 24-hour cutoff filter |
 | **TLDR AI** | `scraper.py` | HTML scraping via `beautifulsoup4` | Filters by section names; strips UTM params |
 | **GitHub** | `storage.py`, `blog_builder.py` | REST API (Issues), `gh` CLI | 5 issues/run max |
+| **GitHub Trending** | `github_trending.py` | HTML scraping via `beautifulsoup4` | Top 10 repos; Telegram + JSON snapshot only |
 | **Cloudflare Worker** | `worker/index.js` | GitHub API PATCH | Closes issues on "읽음" button click |
 
 ---
@@ -256,6 +260,7 @@ Tests for `main.py` must mock ALL of these (or they make real API calls):
 - `filter_and_summarize`, `create_github_issues`, `send_to_notion`
 - `fetch_model_data`, `save_model_snapshots`, `get_model_updates`
 - `get_latest_models`, `sync_models_to_dashboard`
+- `fetch_github_trending`, `save_daily_trending_repos`
 - `send_model_updates_to_notion`, `send_digest`, `send_failure_notification`
 
 ### Running Tests
@@ -314,6 +319,7 @@ uv run pytest tests/test_foo.py  # Single file
 |------|--------|---------|
 | `data/seen_ids.json` | JSON array (sorted strings) | Deduplication tracking |
 | `data/YYYY/MM/DD.json` | JSON array of article dicts | Daily article archive |
+| `data/github_trending/YYYY/MM/DD.json` | JSON array of repo dicts | Daily GitHub Trending snapshot |
 | `data/models.db` | SQLite | Model tracker snapshots (PK: `model_id + fetched_at`) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ graph TD
 8. **AI 모델 트래킹**: Artificial Analysis API → SQLite 스냅샷 → 변동 감지
 9. **모델 변동 사항**은 별도 Notion "AI Model Tracker" DB에 기록
 10. **AI 모델 현황 대시보드**: 모든 모델 스냅샷 → Notion "AI 모델 현황" DB에 upsert (매일 업데이트)
-11. **텔레그램**으로 뉴스 다이제스트 + 모델 업데이트 발송
+11. **GitHub Trending** 인기 리포지토리 Top 10 스냅샷 저장
+12. **텔레그램**으로 뉴스 다이제스트 + 모델 업데이트 + GitHub Trending 발송
 
 ## 📦 모듈 구성
 
@@ -57,6 +58,7 @@ graph TD
 |------|------|
 | `config.py` | 설정값 및 환경변수 관리 |
 | `scraper.py` | GeekNews Atom 피드 + HN API + TLDR AI 뉴스레터 수집 |
+| `github_trending.py` | GitHub Trending 리포지토리 수집 + 일일 스냅샷 저장 |
 | `model_tracker.py` | Artificial Analysis API 연동 + SQLite 스냅샷 + 변동 감지 |
 | `ai_handler.py` | Gemini 2.5 Flash 배치 요약 + 관련성 점수 + 태그 분류 |
 | `storage.py` | JSON 저장 + 중복 방지 + GitHub Issues 생성 |

--- a/src/config.py
+++ b/src/config.py
@@ -96,6 +96,10 @@ TLDR_SECTIONS = frozenset(
     }
 )
 
+# GitHub Trending Configuration
+GITHUB_TRENDING_URL = "https://github.com/trending"
+GITHUB_TRENDING_COUNT = 10
+
 # Artificial Analysis Configuration
 ARTIFICIAL_ANALYSIS_API_KEY = os.getenv("ARTIFICIAL_ANALYSIS_API_KEY")
 ARTIFICIAL_ANALYSIS_API_URL = "https://artificialanalysis.ai/api/v2/data/llms/models"

--- a/src/github_trending.py
+++ b/src/github_trending.py
@@ -1,0 +1,134 @@
+"""GitHub Trending repository tracking."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup  # type: ignore[import-untyped]
+
+from src import config
+from src.scraper import USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path("data")
+
+
+@dataclass
+class TrendingRepo:
+    name: str
+    url: str
+    description: str
+    language: str | None
+    stars: int
+    today_stars: int
+    forks: int
+
+
+def _parse_count(text: str | None) -> int:
+    """Parse GitHub count text like ``12,345`` or ``1.2k`` into an int."""
+    if not text:
+        return 0
+
+    cleaned = text.strip().lower().replace(",", "")
+    match = re.search(r"(\d+(?:\.\d+)?)\s*([kmb])?", cleaned)
+    if not match:
+        return 0
+
+    value = float(match.group(1))
+    suffix = match.group(2)
+    multiplier = {"k": 1_000, "m": 1_000_000, "b": 1_000_000_000}.get(suffix, 1)
+    return int(value * multiplier)
+
+
+def _clean_repo_name(text: str) -> str:
+    return re.sub(r"\s+", "", text.strip())
+
+
+def fetch_github_trending(count: int | None = None) -> list[TrendingRepo]:
+    """Fetch GitHub Trending repositories from the daily all-language page."""
+    limit = count or config.GITHUB_TRENDING_COUNT
+
+    try:
+        resp = requests.get(
+            config.GITHUB_TRENDING_URL,
+            headers={"User-Agent": USER_AGENT},
+            timeout=15,
+        )
+        resp.raise_for_status()
+    except requests.RequestException:
+        logger.exception("Error fetching GitHub Trending")
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    repos: list[TrendingRepo] = []
+
+    for article in soup.select("article.Box-row"):
+        link = article.select_one("h2 a")
+        if not link:
+            continue
+
+        href = str(link.get("href", "")).strip()
+        name = _clean_repo_name(link.get_text(" ", strip=True))
+        if not href or not name:
+            continue
+
+        description_tag = article.select_one("p")
+        language_tag = article.select_one('[itemprop="programmingLanguage"]')
+        stars_tag = article.find("a", href=re.compile(r"/stargazers$"))
+        forks_tag = article.find("a", href=re.compile(r"/forks$"))
+        today_tag = article.find(string=re.compile(r"stars?\s+today", re.I))
+
+        repos.append(
+            TrendingRepo(
+                name=name,
+                url=urljoin("https://github.com", href),
+                description=description_tag.get_text(" ", strip=True)
+                if description_tag
+                else "",
+                language=language_tag.get_text(strip=True) if language_tag else None,
+                stars=_parse_count(stars_tag.get_text(" ", strip=True))
+                if stars_tag
+                else 0,
+                today_stars=_parse_count(str(today_tag)) if today_tag else 0,
+                forks=_parse_count(forks_tag.get_text(" ", strip=True))
+                if forks_tag
+                else 0,
+            )
+        )
+
+        if len(repos) >= limit:
+            break
+
+    if not repos:
+        logger.warning(
+            "GitHub Trending page returned 200 but no repos parsed; "
+            "selectors may be broken"
+        )
+
+    logger.info("Fetched %d repositories from GitHub Trending", len(repos))
+    return repos
+
+
+def save_daily_trending_repos(repos: list[TrendingRepo], date_str: str) -> Path:
+    """Save daily GitHub Trending repository snapshots."""
+    parts = date_str.split("-")
+    if len(parts) != 3:
+        raise ValueError(f"Invalid date format: {date_str}, expected YYYY-MM-DD")
+
+    year, month, day = parts
+    dir_path = DATA_DIR / "github_trending" / year / month
+    dir_path.mkdir(parents=True, exist_ok=True)
+
+    file_path = dir_path / f"{day}.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump([asdict(repo) for repo in repos], f, indent=2, ensure_ascii=False)
+
+    logger.info("Saved %d GitHub Trending repos to %s", len(repos), file_path)
+    return file_path

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,11 @@ import requests
 from src import config
 from src.config import validate_env
 from src.ai_handler import filter_and_summarize
+from src.github_trending import (
+    TrendingRepo,
+    fetch_github_trending,
+    save_daily_trending_repos,
+)
 from src.model_tracker import (
     fetch_model_data,
     get_latest_models,
@@ -25,7 +30,7 @@ from src.notion_handler import send_to_notion
 from src.notion_model_dashboard import sync_models_to_dashboard
 from src.notion_model_handler import send_model_updates_to_notion
 from src.notifier import send_digest, send_failure_notification
-from src.scraper import scrape_all
+from src.scraper import Article, scrape_all
 from src.storage import (
     create_github_issues,
     filter_new_articles,
@@ -47,6 +52,8 @@ def setup_logging() -> None:
 
 def main(dry_run: bool = False) -> None:
     try:
+        today = datetime.now(config.KST).strftime("%Y-%m-%d")
+
         # 1. Data collection
         logger.info("Starting data collection...")
         all_articles = asyncio.run(scrape_all())
@@ -57,32 +64,32 @@ def main(dry_run: bool = False) -> None:
         new_articles = filter_new_articles(all_articles, seen_ids)
         logger.info("New articles: %d", len(new_articles))
 
-        if not new_articles:
-            logger.info("No new articles found. Exiting.")
-            return
+        processed: list[Article] = []
 
-        # 3. Keyword filter + AI summary
-        processed = filter_and_summarize(new_articles)
-        logger.info("After filtering: %d articles", len(processed))
+        if new_articles:
+            # 3. Keyword filter + AI summary
+            processed = filter_and_summarize(new_articles)
+            logger.info("After filtering: %d articles", len(processed))
 
-        # 4. Save data
-        today = datetime.now().strftime("%Y-%m-%d")
-        save_daily_articles(processed, today)
-        save_seen_ids(seen_ids)
+            # 4. Save data
+            save_daily_articles(processed, today)
+            save_seen_ids(seen_ids)
 
-        # 5. GitHub Issues
-        if not dry_run:
-            create_github_issues(processed)
-            logger.info("GitHub Issues created")
+            # 5. GitHub Issues
+            if not dry_run:
+                create_github_issues(processed)
+                logger.info("GitHub Issues created")
+            else:
+                logger.info("[DRY RUN] GitHub Issues creation skipped")
+
+            # 6. Notion
+            if not dry_run:
+                send_to_notion(processed)
+                logger.info("Notion database updated")
+            else:
+                logger.info("[DRY RUN] Notion update skipped")
         else:
-            logger.info("[DRY RUN] GitHub Issues creation skipped")
-
-        # 6. Notion
-        if not dry_run:
-            send_to_notion(processed)
-            logger.info("Notion database updated")
-        else:
-            logger.info("[DRY RUN] Notion update skipped")
+            logger.info("No new articles found. Continuing to model tracker.")
 
         # 7. Model Tracker
         model_updates: dict[str, list[dict[str, object]]] | None = None
@@ -129,9 +136,26 @@ def main(dry_run: bool = False) -> None:
         ):
             logger.exception("Model dashboard sync failed (non-fatal)")
 
+        # 7.7 GitHub Trending — Telegram + JSON snapshot only
+        trending_repos: list[TrendingRepo] = []
+        try:
+            trending_repos = fetch_github_trending()
+            if trending_repos:
+                save_daily_trending_repos(trending_repos, today)
+                logger.info("Saved %d GitHub Trending repos", len(trending_repos))
+            else:
+                logger.info("No GitHub Trending repos collected")
+        except Exception:
+            logger.exception("GitHub Trending tracking failed (non-fatal)")
+
         # 8. Telegram digest
         if not dry_run:
-            send_digest(processed, model_updates=model_updates)
+            if not send_digest(
+                processed,
+                model_updates=model_updates,
+                trending_repos=trending_repos,
+            ):
+                raise RuntimeError("Telegram digest failed")
             logger.info("Telegram digest sent")
         else:
             logger.info("[DRY RUN] Telegram send skipped")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -9,6 +9,7 @@ from typing import Any
 import requests
 
 from src import config
+from src.github_trending import TrendingRepo
 from src.scraper import Article
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,7 @@ def _escape_md(text: str | None) -> str:
     if text is None:
         return ""
     return re.sub(r"([_*\[\]()~`>#+\-=|{}.!\\])", r"\\\1", str(text))
+
 
 def _escape_url(url: str | None) -> str:
     """Escape a URL for use inside MarkdownV2 inline links.
@@ -30,9 +32,11 @@ def _escape_url(url: str | None) -> str:
         return ""
     return str(url).replace("\\", "\\\\").replace(")", "\\)")
 
+
 def format_digest(
     articles: list[Article],
     model_updates: dict[str, list[dict[str, Any]]] | None = None,
+    trending_repos: list[TrendingRepo] | None = None,
 ) -> str:
     """Format articles into a Telegram MarkdownV2 daily digest, grouped by source."""
     now = datetime.now(timezone.utc)
@@ -115,6 +119,36 @@ def format_digest(
                     lines.append(
                         f"💰 {model_name}: \\${old_price} → \\${new_price} \\({change_pct}%\\)\n"
                     )
+
+    if trending_repos:
+        lines.append(_format_trending(trending_repos))
+
+    return "\n".join(lines)
+
+
+def _format_trending(repos: list[TrendingRepo]) -> str:
+    """Format GitHub Trending repositories as a Telegram MarkdownV2 section."""
+    if not repos:
+        return ""
+
+    lines: list[str] = ["🔥 *GitHub Trending*\n"]
+    for index, repo in enumerate(repos, 1):
+        name = _escape_md(repo.name)
+        url = _escape_url(repo.url)
+        description = _escape_md(repo.description)
+        stars = _escape_md(f"{repo.stars:,}")
+        today_stars = _escape_md(f"+{repo.today_stars:,} today")
+
+        detail_parts = []
+        if repo.language:
+            detail_parts.append(_escape_md(repo.language))
+        if description:
+            detail_parts.append(description)
+        detail = " \\| ".join(detail_parts)
+
+        lines.append(
+            f"{index}\\. [{name}]({url}) ⭐ {stars} \\({today_stars}\\)\n{detail}\n"
+        )
 
     return "\n".join(lines)
 
@@ -208,13 +242,27 @@ def send_telegram(text: str) -> bool:
 def send_digest(
     articles: list[Article],
     model_updates: dict[str, list[dict[str, Any]]] | None = None,
+    trending_repos: list[TrendingRepo] | None = None,
 ) -> bool:
     """Format articles into digest, chunk, and send via Telegram (1s between chunks)."""
-    if not articles:
-        logger.info("No articles to send in digest")
+    has_model_updates = bool(
+        model_updates
+        and (
+            model_updates.get("new_models")
+            or model_updates.get("rank_changes")
+            or model_updates.get("price_changes")
+        )
+    )
+    has_trending = bool(trending_repos)
+    if not articles and not has_model_updates and not has_trending:
+        logger.info("No articles, model updates, or GitHub Trending repos to send")
         return True
 
-    text = format_digest(articles, model_updates)
+    text = format_digest(
+        articles,
+        model_updates,
+        trending_repos=trending_repos,
+    )
     chunks = chunk_message(text)
 
     logger.info(

--- a/tests/test_github_trending.py
+++ b/tests/test_github_trending.py
@@ -1,0 +1,131 @@
+"""Tests for GitHub Trending repository tracking."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from src.github_trending import (
+    TrendingRepo,
+    fetch_github_trending,
+    save_daily_trending_repos,
+)
+
+
+_TRENDING_HTML = """
+<html>
+  <body>
+    <article class="Box-row">
+      <h2>
+        <a href="/owner-one/repo.one">
+          owner-one / repo.one
+        </a>
+      </h2>
+      <p>First repo description</p>
+      <span itemprop="programmingLanguage">Python</span>
+      <a href="/owner-one/repo.one/stargazers">12,345</a>
+      <a href="/owner-one/repo.one/forks">678</a>
+      <span class="d-inline-block float-sm-right">123 stars today</span>
+    </article>
+    <article class="Box-row">
+      <h2>
+        <a href="/owner_two/repo-two">
+          owner_two / repo-two
+        </a>
+      </h2>
+      <p>Second repo description</p>
+      <a href="/owner_two/repo-two/stargazers">2,000</a>
+      <a href="/owner_two/repo-two/forks">50</a>
+      <span class="d-inline-block float-sm-right">42 stars today</span>
+    </article>
+  </body>
+</html>
+"""
+
+
+@patch("src.github_trending.requests.get")
+def test_fetch_github_trending_parses_repositories(mock_get: MagicMock) -> None:
+    mock_resp = MagicMock()
+    mock_resp.text = _TRENDING_HTML
+    mock_resp.raise_for_status = MagicMock()
+    mock_get.return_value = mock_resp
+
+    repos = fetch_github_trending(count=10)
+
+    assert len(repos) == 2
+    assert repos[0] == TrendingRepo(
+        name="owner-one/repo.one",
+        url="https://github.com/owner-one/repo.one",
+        description="First repo description",
+        language="Python",
+        stars=12345,
+        today_stars=123,
+        forks=678,
+    )
+    assert repos[1].name == "owner_two/repo-two"
+    assert repos[1].language is None
+    assert repos[1].today_stars == 42
+
+
+@patch("src.github_trending.requests.get")
+def test_fetch_github_trending_respects_count(mock_get: MagicMock) -> None:
+    mock_resp = MagicMock()
+    mock_resp.text = _TRENDING_HTML
+    mock_resp.raise_for_status = MagicMock()
+    mock_get.return_value = mock_resp
+
+    repos = fetch_github_trending(count=1)
+
+    assert [repo.name for repo in repos] == ["owner-one/repo.one"]
+
+
+@patch("src.github_trending.requests.get")
+def test_fetch_github_trending_returns_empty_on_network_error(
+    mock_get: MagicMock,
+) -> None:
+    mock_get.side_effect = requests.RequestException("timeout")
+
+    assert fetch_github_trending() == []
+
+
+@patch("src.github_trending.requests.get")
+def test_fetch_github_trending_warns_when_selectors_parse_nothing(
+    mock_get: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_resp = MagicMock()
+    mock_resp.text = "<html><body>No trending rows</body></html>"
+    mock_resp.raise_for_status = MagicMock()
+    mock_get.return_value = mock_resp
+
+    repos = fetch_github_trending()
+
+    assert repos == []
+    assert "selectors may be broken" in caplog.text
+
+
+def test_save_daily_trending_repos(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import src.github_trending as github_trending
+
+    monkeypatch.setattr(github_trending, "DATA_DIR", tmp_path)
+    repos = [
+        TrendingRepo(
+            name="owner/repo",
+            url="https://github.com/owner/repo",
+            description="Description",
+            language="Python",
+            stars=10,
+            today_stars=2,
+            forks=1,
+        )
+    ]
+
+    path = save_daily_trending_repos(repos, "2026-04-11")
+
+    assert path == tmp_path / "github_trending" / "2026" / "04" / "11.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data[0]["name"] == "owner/repo"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,20 @@
 """Tests for src.main pipeline orchestration."""
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
+
+from src import config
+
+
+@pytest.fixture(autouse=True)
+def mock_github_trending_pipeline():
+    """Keep main.py orchestration tests isolated from GitHub Trending network I/O."""
+    with (
+        patch("src.main.fetch_github_trending", return_value=[]),
+        patch("src.main.save_daily_trending_repos"),
+    ):
+        yield
 
 
 class TestSeenIdsSaveTiming:
@@ -298,3 +310,288 @@ class TestModelDashboardIntegration:
 
         mock_get_latest.assert_called_once()
         mock_sync_dashboard.assert_called_once_with([{"model_id": "m1"}])
+
+
+class TestPipelineResilience:
+    @patch("src.main.send_digest")
+    @patch("src.main.sync_models_to_dashboard", return_value=0)
+    @patch("src.main.get_latest_models", return_value=[])
+    @patch("src.main.send_model_updates_to_notion", return_value=0)
+    @patch("src.main.send_to_notion")
+    @patch("src.main.create_github_issues")
+    @patch("src.main.save_seen_ids")
+    @patch("src.main.save_daily_articles")
+    @patch("src.main.filter_and_summarize")
+    @patch("src.main.filter_new_articles")
+    @patch("src.main.load_seen_ids")
+    @patch("src.main.scrape_all")
+    @patch("src.main.fetch_model_data")
+    @patch("src.main.save_model_snapshots")
+    @patch("src.main.get_model_updates")
+    def test_model_tracker_runs_when_no_new_articles(
+        self,
+        mock_get_model_updates,
+        mock_save_snapshots,
+        mock_fetch_model,
+        mock_scrape,
+        mock_load_seen,
+        mock_filter_new,
+        mock_filter_summarize,
+        mock_save_daily,
+        mock_save_seen,
+        mock_create_issues,
+        mock_send_notion,
+        mock_send_model_notion,
+        mock_get_latest,
+        mock_sync_dashboard,
+        mock_send_digest,
+        sample_articles,
+    ):
+        from src.main import main
+
+        mock_scrape.return_value = sample_articles
+        mock_load_seen.return_value = {"hackernews:12345"}
+        mock_filter_new.return_value = []
+        mock_fetch_model.return_value = [{"model_id": "m1", "name": "Model 1"}]
+        mock_get_model_updates.return_value = {
+            "new_models": [],
+            "rank_changes": [],
+            "price_changes": [],
+        }
+
+        main(dry_run=True)
+
+        mock_filter_summarize.assert_not_called()
+        mock_save_daily.assert_not_called()
+        mock_save_seen.assert_not_called()
+        mock_fetch_model.assert_called_once()
+        mock_save_snapshots.assert_called_once()
+        mock_get_model_updates.assert_called_once()
+        mock_get_latest.assert_called_once()
+
+    @patch("src.main.datetime")
+    @patch("src.main.send_digest")
+    @patch("src.main.sync_models_to_dashboard", return_value=0)
+    @patch("src.main.get_latest_models", return_value=[])
+    @patch("src.main.send_model_updates_to_notion", return_value=0)
+    @patch("src.main.send_to_notion")
+    @patch("src.main.create_github_issues")
+    @patch("src.main.save_seen_ids")
+    @patch("src.main.save_daily_articles")
+    @patch("src.main.filter_and_summarize")
+    @patch("src.main.filter_new_articles")
+    @patch("src.main.load_seen_ids")
+    @patch("src.main.scrape_all")
+    @patch("src.main.fetch_model_data")
+    @patch("src.main.save_model_snapshots")
+    @patch("src.main.get_model_updates")
+    def test_pipeline_date_uses_kst(
+        self,
+        mock_get_model_updates,
+        mock_save_snapshots,
+        mock_fetch_model,
+        mock_scrape,
+        mock_load_seen,
+        mock_filter_new,
+        mock_filter_summarize,
+        mock_save_daily,
+        mock_save_seen,
+        mock_create_issues,
+        mock_send_notion,
+        mock_send_model_notion,
+        mock_get_latest,
+        mock_sync_dashboard,
+        mock_send_digest,
+        mock_datetime,
+        sample_articles,
+    ):
+        from src.main import main
+
+        mock_datetime.now.return_value.strftime.return_value = "2026-04-11"
+        mock_scrape.return_value = sample_articles
+        mock_load_seen.return_value = set()
+        mock_filter_new.return_value = sample_articles
+        mock_filter_summarize.return_value = sample_articles
+        mock_get_model_updates.return_value = {
+            "new_models": [],
+            "rank_changes": [],
+            "price_changes": [],
+        }
+
+        main(dry_run=True)
+
+        mock_datetime.now.assert_called_once_with(config.KST)
+        mock_save_daily.assert_called_once_with(sample_articles, "2026-04-11")
+        mock_save_snapshots.assert_called_once_with(
+            mock_fetch_model.return_value,
+            "2026-04-11",
+        )
+        mock_get_latest.assert_called_once_with("2026-04-11")
+
+    @patch("src.main.send_failure_notification")
+    @patch("src.main.send_digest", return_value=False)
+    @patch("src.main.sync_models_to_dashboard", return_value=0)
+    @patch("src.main.get_latest_models", return_value=[])
+    @patch("src.main.send_model_updates_to_notion", return_value=0)
+    @patch("src.main.send_to_notion")
+    @patch("src.main.create_github_issues")
+    @patch("src.main.save_seen_ids")
+    @patch("src.main.save_daily_articles")
+    @patch("src.main.filter_and_summarize")
+    @patch("src.main.filter_new_articles")
+    @patch("src.main.load_seen_ids")
+    @patch("src.main.scrape_all")
+    @patch("src.main.fetch_model_data")
+    @patch("src.main.save_model_snapshots")
+    @patch("src.main.get_model_updates")
+    def test_telegram_false_result_raises(
+        self,
+        mock_get_model_updates,
+        mock_save_snapshots,
+        mock_fetch_model,
+        mock_scrape,
+        mock_load_seen,
+        mock_filter_new,
+        mock_filter_summarize,
+        mock_save_daily,
+        mock_save_seen,
+        mock_create_issues,
+        mock_send_notion,
+        mock_send_model_notion,
+        mock_get_latest,
+        mock_sync_dashboard,
+        mock_send_digest,
+        mock_send_failure,
+        sample_articles,
+    ):
+        from src.main import main
+
+        mock_scrape.return_value = sample_articles
+        mock_load_seen.return_value = set()
+        mock_filter_new.return_value = sample_articles
+        mock_filter_summarize.return_value = sample_articles
+        mock_get_model_updates.return_value = {
+            "new_models": [],
+            "rank_changes": [],
+            "price_changes": [],
+        }
+
+        with pytest.raises(RuntimeError, match="Telegram digest failed"):
+            main(dry_run=False)
+
+        mock_send_failure.assert_called_once()
+
+    @patch("src.main.fetch_github_trending")
+    @patch("src.main.save_daily_trending_repos")
+    @patch("src.main.send_digest", return_value=True)
+    @patch("src.main.sync_models_to_dashboard", return_value=0)
+    @patch("src.main.get_latest_models", return_value=[])
+    @patch("src.main.send_model_updates_to_notion", return_value=0)
+    @patch("src.main.send_to_notion")
+    @patch("src.main.create_github_issues")
+    @patch("src.main.save_seen_ids")
+    @patch("src.main.save_daily_articles")
+    @patch("src.main.filter_and_summarize")
+    @patch("src.main.filter_new_articles")
+    @patch("src.main.load_seen_ids")
+    @patch("src.main.scrape_all")
+    @patch("src.main.fetch_model_data")
+    @patch("src.main.save_model_snapshots")
+    @patch("src.main.get_model_updates")
+    def test_github_trending_is_passed_to_digest(
+        self,
+        mock_get_model_updates,
+        mock_save_snapshots,
+        mock_fetch_model,
+        mock_scrape,
+        mock_load_seen,
+        mock_filter_new,
+        mock_filter_summarize,
+        mock_save_daily,
+        mock_save_seen,
+        mock_create_issues,
+        mock_send_notion,
+        mock_send_model_notion,
+        mock_get_latest,
+        mock_sync_dashboard,
+        mock_send_digest,
+        mock_save_trending,
+        mock_fetch_trending,
+        sample_articles,
+    ):
+        from src.main import main
+
+        model_updates = {"new_models": [], "rank_changes": [], "price_changes": []}
+        trending_repos = [{"name": "owner/repo"}]
+        mock_scrape.return_value = sample_articles
+        mock_load_seen.return_value = set()
+        mock_filter_new.return_value = sample_articles
+        mock_filter_summarize.return_value = sample_articles
+        mock_get_model_updates.return_value = model_updates
+        mock_fetch_trending.return_value = trending_repos
+
+        main(dry_run=False)
+
+        mock_fetch_trending.assert_called_once()
+        mock_save_trending.assert_called_once_with(trending_repos, ANY)
+        mock_send_digest.assert_called_once_with(
+            sample_articles,
+            model_updates=model_updates,
+            trending_repos=trending_repos,
+        )
+
+    @patch("src.main.fetch_github_trending", side_effect=RuntimeError("selectors"))
+    @patch("src.main.save_daily_trending_repos")
+    @patch("src.main.send_digest", return_value=True)
+    @patch("src.main.sync_models_to_dashboard", return_value=0)
+    @patch("src.main.get_latest_models", return_value=[])
+    @patch("src.main.send_model_updates_to_notion", return_value=0)
+    @patch("src.main.send_to_notion")
+    @patch("src.main.create_github_issues")
+    @patch("src.main.save_seen_ids")
+    @patch("src.main.save_daily_articles")
+    @patch("src.main.filter_and_summarize")
+    @patch("src.main.filter_new_articles")
+    @patch("src.main.load_seen_ids")
+    @patch("src.main.scrape_all")
+    @patch("src.main.fetch_model_data")
+    @patch("src.main.save_model_snapshots")
+    @patch("src.main.get_model_updates")
+    def test_github_trending_failure_is_non_fatal(
+        self,
+        mock_get_model_updates,
+        mock_save_snapshots,
+        mock_fetch_model,
+        mock_scrape,
+        mock_load_seen,
+        mock_filter_new,
+        mock_filter_summarize,
+        mock_save_daily,
+        mock_save_seen,
+        mock_create_issues,
+        mock_send_notion,
+        mock_send_model_notion,
+        mock_get_latest,
+        mock_sync_dashboard,
+        mock_send_digest,
+        mock_save_trending,
+        mock_fetch_trending,
+        sample_articles,
+    ):
+        from src.main import main
+
+        model_updates = {"new_models": [], "rank_changes": [], "price_changes": []}
+        mock_scrape.return_value = sample_articles
+        mock_load_seen.return_value = set()
+        mock_filter_new.return_value = sample_articles
+        mock_filter_summarize.return_value = sample_articles
+        mock_get_model_updates.return_value = model_updates
+
+        main(dry_run=False)
+
+        mock_save_trending.assert_not_called()
+        mock_send_digest.assert_called_once_with(
+            sample_articles,
+            model_updates=model_updates,
+            trending_repos=[],
+        )

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,6 +1,9 @@
 """Tests for notifier module - message formatting and URL escaping."""
 
-from src.notifier import _escape_md, _escape_url, format_digest
+from unittest.mock import patch
+
+from src.github_trending import TrendingRepo
+from src.notifier import _escape_md, _escape_url, format_digest, send_digest
 
 
 def test_format_digest_with_new_models(sample_article, sample_model_updates):
@@ -36,6 +39,95 @@ def test_format_digest_with_all_model_updates(sample_article, sample_model_updat
     assert "GPT" in result
     assert "Claude" in result
     assert "Turbo" in result
+
+
+def test_format_digest_with_model_updates_only(sample_model_updates):
+    """format_digest should include model updates even when there are no articles."""
+    result = format_digest([], model_updates=sample_model_updates)
+    assert "InsightFlow Daily Digest" in result
+    assert "AI Model Updates" in result
+    assert "GPT" in result
+
+
+@patch("src.notifier.send_telegram", return_value=True)
+def test_send_digest_sends_model_updates_without_articles(
+    mock_send_telegram, sample_model_updates
+):
+    """send_digest must not return early when only model updates exist."""
+    result = send_digest([], model_updates=sample_model_updates)
+    assert result is True
+    mock_send_telegram.assert_called_once()
+
+
+@patch("src.notifier.send_telegram")
+def test_send_digest_skips_when_no_articles_or_model_updates(mock_send_telegram):
+    """send_digest should only skip when there is no article or model update content."""
+    result = send_digest([], model_updates=None)
+    assert result is True
+    mock_send_telegram.assert_not_called()
+
+
+def test_format_digest_with_github_trending_only():
+    """format_digest should include GitHub Trending repos without articles."""
+    repos = [
+        TrendingRepo(
+            name="owner/repo.name",
+            url="https://github.com/owner/repo.name",
+            description="Build AI tools faster",
+            language="Python",
+            stars=12345,
+            today_stars=678,
+            forks=90,
+        )
+    ]
+
+    result = format_digest([], trending_repos=repos)
+
+    assert "GitHub Trending" in result
+    assert "owner/repo\\.name" in result
+    assert "12,345" in result
+    assert "\\+678 today" in result
+    assert "Python" in result
+
+
+def test_format_digest_with_github_trending_without_language():
+    repos = [
+        TrendingRepo(
+            name="owner/repo",
+            url="https://github.com/owner/repo",
+            description="No language repo",
+            language=None,
+            stars=1,
+            today_stars=1,
+            forks=0,
+        )
+    ]
+
+    result = format_digest([], trending_repos=repos)
+
+    assert "No language repo" in result
+    assert "None" not in result
+
+
+@patch("src.notifier.send_telegram", return_value=True)
+def test_send_digest_sends_github_trending_without_articles(mock_send_telegram):
+    repos = [
+        TrendingRepo(
+            name="owner/repo",
+            url="https://github.com/owner/repo",
+            description="Description",
+            language="Rust",
+            stars=5,
+            today_stars=2,
+            forks=1,
+        )
+    ]
+
+    result = send_digest([], trending_repos=repos)
+
+    assert result is True
+    mock_send_telegram.assert_called_once()
+
 
 def test_format_digest_with_none_creator(sample_article):
     """format_digest must handle model updates where 'creator' is None (from API)."""


### PR DESCRIPTION
## Summary

- Add GitHub Trending repository tracking with daily JSON snapshots under `data/github_trending/YYYY/MM/DD.json`.
- Include a GitHub Trending section in Telegram digests, including support for digest-only Trending content.
- Wire the Trending step into the main pipeline as a non-fatal step and document the new module/storage path.

## Validation

- `uv run pytest tests/ -v` -> `143 passed`
- `git diff --check` -> passed