### PR TITLE
[codex] Add GitHub Trending-only workflow

### DIFF
--- a/.github/workflows/github-trending.yml
+++ b/.github/workflows/github-trending.yml
@@ -1,0 +1,49 @@
+name: GitHub Trending Digest
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: github-trending-digest
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  send-trending:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install Dependencies
+        run: uv sync
+
+      - name: Send GitHub Trending Digest
+        env:
+          DRY_RUN: "false"
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          uv run python -c "
+          from src.github_trending import fetch_github_trending
+          from src.notifier import send_digest
+
+          repos = fetch_github_trending(count=10)
+          if not repos:
+              raise SystemExit('No GitHub Trending repositories parsed; skipping Telegram send')
+
+          if not send_digest([], trending_repos=repos):
+              raise SystemExit('Telegram send failed')
+          "

--- a/tests/test_github_trending_workflow.py
+++ b/tests/test_github_trending_workflow.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(".github/workflows/github-trending.yml")
+
+
+def test_github_trending_workflow_is_manual_only() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in text
+    assert "schedule:" not in text
+
+
+def test_github_trending_workflow_uses_minimal_permissions() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "contents: read" in text
+    assert "contents: write" not in text
+    assert "issues: write" not in text
+
+
+def test_github_trending_workflow_only_sends_trending_digest() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "fetch_github_trending" in text
+    assert "send_digest([], trending_repos=repos)" in text
+    assert "python -m src.main" not in text
+    assert "git add data/" not in text


### PR DESCRIPTION
## Summary

- Add a manual `GitHub Trending Digest` workflow that only fetches GitHub Trending repos and sends the Telegram digest.
- Keep permissions minimal with `contents: read` and avoid running the full daily pipeline or committing `data/`.
- Add workflow text tests to guard the manual-only, minimal-permission behavior.

## Validation

- `uv run pytest tests/test_github_trending_workflow.py -v` -> `3 passed`
- `git diff --check` -> passed

## Note

GitHub Actions only exposes new workflow files for manual dispatch after the workflow exists on the default branch. After this PR is merged into `main`, run `GitHub Trending Digest` from the Actions tab.